### PR TITLE
Corrected reference to tenants database.

### DIFF
--- a/Learning Modules/Schema Management/DeployReferenceData.sql
+++ b/Learning Modules/Schema Management/DeployReferenceData.sql
@@ -9,7 +9,7 @@ SET @WtpUser = '<WtpUser>';
 EXEC [jobs].sp_add_target_group @target_group_name = 'DemoServerGroup'
 
 -- Add a server target member, includes all databases in tenant server
-SET @server1 = 'customers1-' + @WtpUser + '.database.windows.net'
+SET @server1 = 'tenants1-' + @WtpUser + '.database.windows.net'
 
 EXEC [jobs].sp_add_target_group_member
 @target_group_name =  'DemoServerGroup',


### PR DESCRIPTION
The original text used 'customer' but that is incorrect. The scripts create a tenants1-<userID> server, not a customer one.